### PR TITLE
[置換後の値に環境変数のSERVER_NAMEを使う]のプラグイン設定の追加。

### DIFF
--- a/plugins/AdminScreenReplaceLink/config.yaml
+++ b/plugins/AdminScreenReplaceLink/config.yaml
@@ -27,3 +27,4 @@ callbacks:
 settings:
     adminscreenreplacelink_search:
     adminscreenreplacelink_replace:
+    adminscreenreplacelink_use_servername:

--- a/plugins/AdminScreenReplaceLink/lib/AdminScreenReplaceLink/L10N/ja.pm
+++ b/plugins/AdminScreenReplaceLink/lib/AdminScreenReplaceLink/L10N/ja.pm
@@ -6,6 +6,7 @@ use vars qw( %Lexicon );
 our %Lexicon = (
     'It replace link in admin screen.' => '管理画面のリンクURLを置換します。',
     'Replace' => '置換',
+    'UseServerName' => '置換後の値に環境変数のSERVER_NAMEを使う',
  );
 
 1;

--- a/plugins/AdminScreenReplaceLink/lib/AdminScreenReplaceLink/Plugin.pm
+++ b/plugins/AdminScreenReplaceLink/lib/AdminScreenReplaceLink/Plugin.pm
@@ -118,7 +118,7 @@ sub _list_asset {
     for my $asset ( @$assets ) {
         my $new;
         for my $col( @$asset ) {
-            if ( $col =~ /__mode=view&_type=asset&blog_id=([0-9]{1,})/ ) {
+            if ( $col =~ /__mode=view.*?&_type=asset.*?&blog_id=([0-9]{1,})/ || $col =~ /__mode=view.*?&blog_id=([0-9]{1,}).*?&_type=asset/ ) {
                 my ( $search, $replace ) = __get_config( $app, $1 );
                 if ( $search && $replace ) {
                     $search  = MT::Util::encode_html( $search );

--- a/plugins/AdminScreenReplaceLink/lib/AdminScreenReplaceLink/Plugin.pm
+++ b/plugins/AdminScreenReplaceLink/lib/AdminScreenReplaceLink/Plugin.pm
@@ -199,6 +199,7 @@ sub __get_config {
     my ( $app, $blog_id ) = @_;
     my $plugin = MT->component( 'AdminScreenReplaceLink' );
     my ( $search, $replace );
+    my $use_servername = 0;
     my $blog;
     if ( $blog_id ) {
         $blog = MT::Blog->load( $blog_id );
@@ -210,16 +211,22 @@ sub __get_config {
     if ( $blog ) {
         $search  = $plugin->get_config_value( 'adminscreenreplacelink_search', 'blog:' . $blog->id );
         $replace = $plugin->get_config_value( 'adminscreenreplacelink_replace', 'blog:' . $blog->id );
+        $use_servername = $plugin->get_config_value( 'adminscreenreplacelink_use_servername', 'blog:' . $blog->id );
         if ( (! $search ) && (! $replace ) ) {
             if ( $blog->class eq 'blog' ) {
                 $search  = $plugin->get_config_value( 'adminscreenreplacelink_search', 'blog:' . $blog->parent_id );
                 $replace = $plugin->get_config_value( 'adminscreenreplacelink_replace', 'blog:' . $blog->parent_id );
+                $use_servername = $plugin->get_config_value( 'adminscreenreplacelink_use_servername', 'blog:' . $blog->parent_id );
             }
         }
     }
     if ( (! $search ) && (! $replace ) ) {
         $search  = $plugin->get_config_value( 'adminscreenreplacelink_search' );
         $replace = $plugin->get_config_value( 'adminscreenreplacelink_replace' );
+        $use_servername = $plugin->get_config_value( 'adminscreenreplacelink_use_servername' );
+    }
+    if ( $use_servername ) {
+        $replace = $ENV{'SERVER_NAME'};
     }
     return ( $search, $replace );
 }

--- a/plugins/AdminScreenReplaceLink/tmpl/config.tmpl
+++ b/plugins/AdminScreenReplaceLink/tmpl/config.tmpl
@@ -12,3 +12,10 @@
 <li><input type="text" class="text" value="<mt:var name="adminscreenreplacelink_replace" escape="html">" name="adminscreenreplacelink_replace" id="adminscreenreplacelink_replace" /></li>
 </ul>
 </mtapp:setting>
+<mtapp:setting
+    id="adminscreenreplacelink_use_servername"
+    label="<__trans phrase="UseServerName">">
+<ul>
+<li><input type="checkbox" value="1" name="adminscreenreplacelink_use_servername" id="adminscreenreplacelink_use_servername"<mt:if name="adminscreenreplacelink_use_servername"> checked="checked"</mt:if> /></li>
+</ul>
+</mtapp:setting>


### PR DESCRIPTION
プラグイン設定に[置換後の値に環境変数のSERVER_NAMEを使う]を追加しました。
この設定をonにすると、置換後の値をENV{'SERVER_NAME'}から取得した値にします。
同一環境が複数のIPでアクセスされる場合などに利用します。